### PR TITLE
Don't use assertions for flow control

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -698,7 +698,8 @@ class nlmsg_base(dict):
         if lvalue is self:
             for key in self:
                 try:
-                    assert self.get(key) == rvalue.get(key)
+                    if self.get(key) != rvalue.get(key):
+                        return False
                 except Exception:
                     # on any error -- is not equal
                     return False
@@ -1429,11 +1430,12 @@ class nlmsg_atoms(nlmsg_base):
 
         def decode(self):
             nla_base.decode(self)
-            try:
-                assert sys.version[0] == '3'
-                self.value = self['value'].decode('utf-8')
-            except (AssertionError, UnicodeDecodeError):
-                self.value = self['value']
+            self.value = self['value']
+            if sys.version_info.major >= 3:
+                try:
+                    self.value = self.value.decode('utf-8')
+                except UnicodeDecodeError:
+                    pass  # Failed to decode, keep undecoded value
 
     class asciiz(string):
         '''


### PR DESCRIPTION
Converted catching AssertionError to normal if statements. Asserts should not be used for this kind of purpose (program flow control).

We got a tremendous performance improvement (run time dropped from 70 seconds to 3 seconds) after doing this fix on Python 2.x & Py.test based device protocol tester. Py.test does "assertion rewriting" ( http://pybites.blogspot.fi/2011/07/behind-scenes-of-pytests-new-assertion.html ) when an assertion error is encountered in addition to normal call stack tracing. This seems to slow down the program quite a lot.